### PR TITLE
Feature/playlist-sorting

### DIFF
--- a/pages/me/playlist/[id]/index.tsx
+++ b/pages/me/playlist/[id]/index.tsx
@@ -29,6 +29,7 @@ export default function Playlist({ clientId, clientSecret, authUrl }: CredProps)
   const [tracks, setTracks] = useState<PlaylistTrack[]>([]);
   const [shownTracks, setShownTracks] = useState<PlaylistTrack[]>([]);
   const [modal, setModal] = useState(-1);
+  const [descending, setDescending] = useState(true);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const router = useRouter();
@@ -125,6 +126,21 @@ export default function Playlist({ clientId, clientSecret, authUrl }: CredProps)
         </span>
       )}
       {pl && pl.description && <span>{escapeHex(pl.description)}</span>}
+      <span>
+        <select>
+          <option value="name">Name</option>
+          <option value="album">Album</option>
+          <option value="artist">Artist</option>
+          <option value="added-at">Added at</option>
+          <option value="duration">Duration</option>
+        </select>
+      </span>
+      <span>
+        <select onChange={(e) => setDescending(e.target.value === "desc")} value={descending ? "desc" : "asc"}>
+          <option value="asc">Ascending</option>
+          <option value="desc">Descending</option>
+        </select>
+      </span>
       {error && <span className="error">{error}</span>}
       <main>
         <div className={styles.tracks}>

--- a/pages/me/playlist/[id]/index.tsx
+++ b/pages/me/playlist/[id]/index.tsx
@@ -6,11 +6,9 @@ import ExternalLink from "../../../../src/components/ExternalLink";
 import Result from "../../../../src/components/Result";
 import GenerateButton from "../../../../src/components/GenerateButton";
 import SkeletonTrack from "../../../../src/components/SkeletonTrack";
-import { CredProps, escapeHex, getCreds, requireLogin } from "../../../../src/util";
+import { CredProps, escapeHex, getCreds, requireLogin, Sort } from "../../../../src/util";
 import { getAllPlaylistTracks, PlaylistTrack } from "../../../../src/getPlaylistTracks";
 import styles from "../../../../styles/pages/Playlist.module.sass";
-
-type Sort = "default" | "name" | "album" | "artist" | "added-at" | "duration";
 
 export async function getStaticPaths() {
   return {
@@ -31,7 +29,7 @@ export default function Playlist({ clientId, clientSecret, authUrl }: CredProps)
   const [tracks, setTracks] = useState<PlaylistTrack[]>([]);
   const [shownTracks, setShownTracks] = useState<PlaylistTrack[]>([]);
   const [modal, setModal] = useState(-1);
-  const [descending, setDescending] = useState(true);
+  const [descending, setDescending] = useState(false);
   const [sort, setSort] = useState<Sort>("default");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");

--- a/pages/me/playlist/[id]/index.tsx
+++ b/pages/me/playlist/[id]/index.tsx
@@ -6,7 +6,7 @@ import ExternalLink from "../../../../src/components/ExternalLink";
 import Result from "../../../../src/components/Result";
 import GenerateButton from "../../../../src/components/GenerateButton";
 import SkeletonTrack from "../../../../src/components/SkeletonTrack";
-import { CredProps, escapeHex, getCreds, requireLogin, Sort } from "../../../../src/util";
+import { CredProps, escapeHex, getCreds, requireLogin, Sort, sort, SortOrder } from "../../../../src/util";
 import { getAllPlaylistTracks, PlaylistTrack } from "../../../../src/getPlaylistTracks";
 import styles from "../../../../styles/pages/Playlist.module.sass";
 
@@ -29,7 +29,7 @@ export default function Playlist({ clientId, clientSecret, authUrl }: CredProps)
   const [tracks, setTracks] = useState<PlaylistTrack[]>([]);
   const [shownTracks, setShownTracks] = useState<PlaylistTrack[]>([]);
   const [modal, setModal] = useState(-1);
-  const [descending, setDescending] = useState(false);
+  const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
   const [sort, setSort] = useState<Sort>("default");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -138,7 +138,7 @@ export default function Playlist({ clientId, clientSecret, authUrl }: CredProps)
         </select>
       </span>
       <span>
-        <select onChange={(e) => setDescending(e.target.value === "desc")} value={descending ? "desc" : "asc"}>
+        <select onChange={(e) => setSortOrder(e.target.value as SortOrder)} value={sortOrder}>
           <option value="asc">Ascending</option>
           <option value="desc">Descending</option>
         </select>

--- a/pages/me/playlist/[id]/index.tsx
+++ b/pages/me/playlist/[id]/index.tsx
@@ -6,7 +6,7 @@ import ExternalLink from "../../../../src/components/ExternalLink";
 import Result from "../../../../src/components/Result";
 import GenerateButton from "../../../../src/components/GenerateButton";
 import SkeletonTrack from "../../../../src/components/SkeletonTrack";
-import { CredProps, escapeHex, getCreds, requireLogin, Sort, sort, SortOrder } from "../../../../src/util";
+import { CredProps, escapeHex, getCreds, requireLogin, Sort, sortTracks, SortOrder } from "../../../../src/util";
 import { getAllPlaylistTracks, PlaylistTrack } from "../../../../src/getPlaylistTracks";
 import styles from "../../../../styles/pages/Playlist.module.sass";
 
@@ -26,8 +26,8 @@ export async function getStaticProps() {
 export default function Playlist({ clientId, clientSecret, authUrl }: CredProps) {
   const updater = new Updater({ clientId, clientSecret });
   const [pl, setPl] = useState<SpotifyApi.SinglePlaylistResponse>();
-  const [tracks, setTracks] = useState<PlaylistTrack[]>([]);
-  const [shownTracks, setShownTracks] = useState<PlaylistTrack[]>([]);
+  const [tracks, _setTracks] = useState<PlaylistTrack[]>([]);
+  const [shownTracks, _setShownTracks] = useState<PlaylistTrack[]>([]);
   const [modal, setModal] = useState(-1);
   const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
   const [sort, setSort] = useState<Sort>("default");
@@ -36,6 +36,9 @@ export default function Playlist({ clientId, clientSecret, authUrl }: CredProps)
   const router = useRouter();
   const id = router.query.id as string;
   const liked = id === "liked";
+
+  const setShownTracks = (tracks: PlaylistTrack[]) => _setShownTracks(sortTracks(sortOrder, sort, tracks));
+  const setTracks = (tracks: PlaylistTrack[]) => _setTracks(sortTracks(sortOrder, sort, tracks));
 
   useEffect(() => {
     requireLogin(updater, authUrl);
@@ -109,6 +112,13 @@ export default function Playlist({ clientId, clientSecret, authUrl }: CredProps)
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    if (tracks.length === pl?.tracks.total) {
+      setTracks(tracks);
+      setShownTracks(tracks.slice(0, 50));
+    }
+  }, [sort, sortOrder]);
 
   return (
     <div className="container">

--- a/pages/me/playlist/[id]/index.tsx
+++ b/pages/me/playlist/[id]/index.tsx
@@ -10,6 +10,8 @@ import { CredProps, escapeHex, getCreds, requireLogin } from "../../../../src/ut
 import { getAllPlaylistTracks, PlaylistTrack } from "../../../../src/getPlaylistTracks";
 import styles from "../../../../styles/pages/Playlist.module.sass";
 
+type Sort = "default" | "name" | "album" | "artist" | "added-at" | "duration";
+
 export async function getStaticPaths() {
   return {
     paths: [],
@@ -30,6 +32,7 @@ export default function Playlist({ clientId, clientSecret, authUrl }: CredProps)
   const [shownTracks, setShownTracks] = useState<PlaylistTrack[]>([]);
   const [modal, setModal] = useState(-1);
   const [descending, setDescending] = useState(true);
+  const [sort, setSort] = useState<Sort>("default");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const router = useRouter();
@@ -127,7 +130,8 @@ export default function Playlist({ clientId, clientSecret, authUrl }: CredProps)
       )}
       {pl && pl.description && <span>{escapeHex(pl.description)}</span>}
       <span>
-        <select>
+        <select onChange={(e) => setSort(e.target.value as Sort)} value={sort}>
+          <option value="default">Default</option>
           <option value="name">Name</option>
           <option value="album">Album</option>
           <option value="artist">Artist</option>

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,13 +1,13 @@
 import Updater from "spotify-oauth-refresher";
 import { PlaylistTrack } from "./getPlaylistTracks";
 
-export function sort(order: "asc" | "desc", sort: Sort, array: PlaylistTrack[]) {
+export function sortTracks(order: "asc" | "desc", sort: Sort, array: PlaylistTrack[]) {
   const desc = order === "desc";
 
   return array.sort((a, b) => {
     switch (sort) {
       case "default":
-        return 0;
+        return desc ? -1 : 1;
 
       case "name":
         return desc ? b.track.name.localeCompare(a.track.name) : a.track.name.localeCompare(b.track.name);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,38 +1,36 @@
 import Updater from "spotify-oauth-refresher";
 import { PlaylistTrack } from "./getPlaylistTracks";
 
-export function sort(order: "asc" | "desc", array: PlaylistTrack[]) {
+export function sort(order: "asc" | "desc", sort: Sort, array: PlaylistTrack[]) {
   const desc = order === "desc";
 
-  return function (sort: Sort) {
-    return array.sort((a, b) => {
-      switch (sort) {
-        case "default":
-          return 0;
+  return array.sort((a, b) => {
+    switch (sort) {
+      case "default":
+        return 0;
 
-        case "name":
-          return desc ? b.track.name.localeCompare(a.track.name) : a.track.name.localeCompare(b.track.name);
+      case "name":
+        return desc ? b.track.name.localeCompare(a.track.name) : a.track.name.localeCompare(b.track.name);
 
-        case "album":
-          return desc
-            ? b.track.album.name.localeCompare(a.track.album.name)
-            : a.track.album.name.localeCompare(b.track.album.name);
+      case "album":
+        return desc
+          ? b.track.album.name.localeCompare(a.track.album.name)
+          : a.track.album.name.localeCompare(b.track.album.name);
 
-        case "artist":
-          return desc
-            ? b.track.artists[0].name.localeCompare(a.track.artists[0].name)
-            : a.track.artists[0].name.localeCompare(b.track.artists[0].name);
+      case "artist":
+        return desc
+          ? b.track.artists[0].name.localeCompare(a.track.artists[0].name)
+          : a.track.artists[0].name.localeCompare(b.track.artists[0].name);
 
-        case "added-at":
-          return desc
-            ? new Date(b.added_at).getTime() - new Date(a.added_at).getTime()
-            : new Date(a.added_at).getTime() - new Date(b.added_at).getTime();
+      case "added-at":
+        return desc
+          ? new Date(b.added_at).getTime() - new Date(a.added_at).getTime()
+          : new Date(a.added_at).getTime() - new Date(b.added_at).getTime();
 
-        case "duration":
-          return desc ? b.track.duration_ms - a.track.duration_ms : a.track.duration_ms - b.track.duration_ms;
-      }
-    });
-  };
+      case "duration":
+        return desc ? b.track.duration_ms - a.track.duration_ms : a.track.duration_ms - b.track.duration_ms;
+    }
+  });
 }
 
 export const escapeHex = (s: string) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -76,6 +76,7 @@ export const scope = [
 ];
 
 export type Sort = "default" | "name" | "album" | "artist" | "added-at" | "duration";
+export type SortOrder = "asc" | "desc";
 
 export interface CredProps {
   clientId: string;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,39 @@
 import Updater from "spotify-oauth-refresher";
+import { PlaylistTrack } from "./getPlaylistTracks";
+
+export function sort(order: "asc" | "desc", array: PlaylistTrack[]) {
+  const desc = order === "desc";
+
+  return function (sort: Sort) {
+    return array.sort((a, b) => {
+      switch (sort) {
+        case "default":
+          return 0;
+
+        case "name":
+          return desc ? b.track.name.localeCompare(a.track.name) : a.track.name.localeCompare(b.track.name);
+
+        case "album":
+          return desc
+            ? b.track.album.name.localeCompare(a.track.album.name)
+            : a.track.album.name.localeCompare(b.track.album.name);
+
+        case "artist":
+          return desc
+            ? b.track.artists[0].name.localeCompare(a.track.artists[0].name)
+            : a.track.artists[0].name.localeCompare(b.track.artists[0].name);
+
+        case "added-at":
+          return desc
+            ? new Date(b.added_at).getTime() - new Date(a.added_at).getTime()
+            : new Date(a.added_at).getTime() - new Date(b.added_at).getTime();
+
+        case "duration":
+          return desc ? b.track.duration_ms - a.track.duration_ms : a.track.duration_ms - b.track.duration_ms;
+      }
+    });
+  };
+}
 
 export const escapeHex = (s: string) => {
   const regex = /&#x([a-fA-F0-9]+);/g;
@@ -39,6 +74,8 @@ export const scope = [
   "playlist-modify-private",
   "user-library-read",
 ];
+
+export type Sort = "default" | "name" | "album" | "artist" | "added-at" | "duration";
 
 export interface CredProps {
   clientId: string;


### PR DESCRIPTION
This pr adds a sorting feature to the /me/playlist/[:id] page. It supports sorting by:

- `name` (`asc` & `desc`)
- `album` (`asc` & `desc`)
- `artist` (`asc` & `desc`)
- `added-at` (`asc` & `desc`)
- `duration` (`asc` & `desc`)